### PR TITLE
feat: add blind and mute options while autojoining

### DIFF
--- a/src/components/SettingsList.tsx
+++ b/src/components/SettingsList.tsx
@@ -30,6 +30,24 @@ const SettingsForm = ({ settingsState: [settings, setSettings] }: Props) => {
         value={settings.autoJoin}
         onChange={onChange}
       />
+      {settings.autoJoin && (
+        <>
+          <Row
+            label=""
+            description="Turn off Camera while auto joining"
+            name="joinBlind"
+            value={settings.joinBlind}
+            onChange={onChange}
+          />
+          <Row
+            label=""
+            description="Mute while auto joining"
+            name="joinMuted"
+            value={settings.joinMuted}
+            onChange={onChange}
+          />
+        </>
+      )}
       <Row
         label="Ask for confirmation before exit"
         description="Restart chrome after enabling this setting"

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,6 +3,30 @@ import { SettingsFormValues } from '../popup/Popup'
 
 const getJoinButton = () => document.getElementsByClassName(joinButtonClass)[0] as HTMLElement
 
+const getCameraButton = (): HTMLElement | undefined => {
+  const elements = document.querySelectorAll('[aria-label]')
+  let cameraElement: HTMLElement | undefined = undefined
+  elements.forEach((element) => {
+    if (element.ariaLabel?.includes('camera') && element.ariaLabel.startsWith('Turn')) {
+      cameraElement = element as HTMLElement
+    }
+  })
+
+  return cameraElement
+}
+
+const getMicrophoneButton = (): HTMLElement | undefined => {
+  const elements = document.querySelectorAll('[aria-label]')
+  let micElement: HTMLElement | undefined = undefined
+  elements.forEach((element) => {
+    if (element.ariaLabel?.includes('microphone') && element.ariaLabel.startsWith('Turn')) {
+      micElement = element as HTMLElement
+    }
+  })
+
+  return micElement
+}
+
 const unloadHandler = (event: BeforeUnloadEvent) => {
   if (document.querySelector('video')) {
     // event.preventDefault() unsupported on chrome
@@ -14,16 +38,55 @@ const unloadHandler = (event: BeforeUnloadEvent) => {
   }
 }
 
-const clickJoinbutton = () => {
+const turnOffCamera = () => {
+  const cameraBtn = getCameraButton()
+  if (cameraBtn && cameraBtn.ariaLabel?.includes('off')) {
+    cameraBtn.click()
+    // return if the button was clicked or not
+    return cameraBtn.ariaLabel.includes('on')
+  }
+  return false
+}
+
+const turnOffMic = () => {
+  const micBtn = getMicrophoneButton()
+  if (micBtn && micBtn.ariaLabel?.includes('off')) {
+    micBtn.click()
+    // return if the button was clicked or not
+    return micBtn.ariaLabel.includes('on')
+  }
+  return false
+}
+
+type JoinOptions = {
+  blind: boolean
+  muted: boolean
+}
+
+const clickJoinbutton = ({ blind, muted }: JoinOptions) => {
   let counter = 0
+  let isMuted = false
+  let isCameraOff = false
 
   // After clicking we don't clear the interval
   // because sometimes clicking the button the first time, doesn't work
   const intervalID = setInterval(() => {
-    const joinButton = getJoinButton()
-    if (joinButton) {
-      joinButton.click()
+    if (blind && !isCameraOff) {
+      isCameraOff = turnOffCamera()
     }
+    if (muted && !isMuted) {
+      isMuted = turnOffMic()
+    }
+
+    const canJoin = blind === isCameraOff && muted === isMuted
+
+    if (canJoin) {
+      const joinButton = getJoinButton()
+      if (joinButton) {
+        joinButton.click()
+      }
+    }
+
     counter++
     if (counter >= 5) {
       clearInterval(intervalID)
@@ -39,7 +102,10 @@ const settingsManager = (settings: SettingsFormValues | undefined) => {
   }
 
   if (settings?.autoJoin) {
-    clickJoinbutton()
+    clickJoinbutton({
+      blind: settings?.joinBlind,
+      muted: settings?.joinMuted,
+    })
   }
 }
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -40,4 +40,6 @@ const settingsFormInitialValues = {
   confirmExit: false,
   disableVideo: false,
   focusTab: false,
+  joinMuted: true,
+  joinBlind: true,
 }

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -55,4 +55,6 @@ export interface SettingsFormValues {
   confirmExit: boolean
   disableVideo: boolean
   autoJoin: boolean
+  joinMuted: boolean
+  joinBlind: boolean
 }


### PR DESCRIPTION
## Description
- Adds two more settings to mute and turn camera off while auto-joining for obvious reasons
- I search the buttons by aria-labels as they can be more reliable as compared to class names
- Fixes #1 

## Testing 
- Check auto join setting and two more settings should open
- Select and check if they work correctly

## Todo

- [ ] Update screenshot
- [ ] Update Readme